### PR TITLE
42 pyinstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ python .\src\main.py --sosi-input "C:path/to/sosi/file" --image-path "C:path/to/
 
 ### Build
 
-TODO: Add build instructions.
+For this application to work, the sosi fyba driver bundle is required. This can be fetched using the script under
+```shell
+.\scripts\fetch_gdal_bundle_win.ps1
+```
+
+Once the env has been activated and bundle has been fetched, build for the platform you are currently on
+```shell
+pyinstaller server.spec
+```
+The `server.spec` file should handle linux/windows lib linking automatically. This does NOT work for linux currently.
+Once the build is finished, it should be present under dist/server in the root of the project.
 
 ## Expanding
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,3 +16,4 @@ dependencies:
   - tifffile
   - pytest
   - chardet
+  - pyinstaller

--- a/server.spec
+++ b/server.spec
@@ -1,0 +1,77 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks.conda import collect_dynamic_libs as collect_conda_dynamic_libs
+
+binaries = []
+hiddenimports = []
+
+# Collect Conda-shared DLLs from env/Library/bin for Windows (shared lib for Unix)
+# This WILL need to be updated as source code changes and more code is added.
+binaries += collect_conda_dynamic_libs("gdal", dependencies=True)
+binaries += collect_conda_dynamic_libs("pillow", dependencies=True)
+binaries += collect_conda_dynamic_libs("rasterio", dependencies=True)
+binaries += collect_conda_dynamic_libs("opencv", dependencies=True)
+binaries += collect_conda_dynamic_libs("pyogrio", dependencies=True)
+
+# This WILL need to be updated as source code changes and more code is added.
+hiddenimports += collect_submodules("rasterio")
+hiddenimports += collect_submodules("numba")
+hiddenimports += collect_submodules("skimage")
+hiddenimports += collect_submodules("geopandas")
+hiddenimports += collect_submodules("tifffile")
+hiddenimports += collect_submodules("imagecodecs")
+hiddenimports += collect_submodules("pyogrio")
+
+# Linux-specific dependency (required by GDAL stack)
+if sys.platform.startswith("linux"):
+    conda_lib = Path(sys.prefix) / "lib"
+    binaries += [(str(conda_lib / "libnsl.so.3"), ".")]
+
+a = Analysis(
+    [str(Path("src") / "main.py")],
+    pathex=[],
+    binaries=binaries,
+    datas=[('lib/bundle', 'lib/bundle')],
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="skavl-anomaly-detection-server",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    contents_directory=".",
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="server",
+)

--- a/src/services/sosi_converter_service/gdal_environment.py
+++ b/src/services/sosi_converter_service/gdal_environment.py
@@ -8,14 +8,19 @@ def get_bundle_root() -> Path:
     Returns:
         the bundle root of the environment
     """
-    project_root = Path(__file__).resolve().parents[3]
-    return project_root / "lib" / "bundle"
+    if getattr(sys, 'frozen', False):
+        base_path = Path(sys.executable).parent
+    else:
+        base_path = Path(__file__).resolve().parents[3]
+    return base_path / "lib" / "bundle"
 
 def setup_gdal_environment():
     """
     Sets up the gdal environment
     """
+
     bundle_root = get_bundle_root()
+    print(f"DEBUG: bundle_root = {bundle_root}")
     if not bundle_root.exists():
         raise FileNotFoundError(f"GDAL bundle not found at {bundle_root}")
 


### PR DESCRIPTION
Closes #42 

Build for windows working. Does not work for linux yet due to bundle pointing to windows dlls. This needs to be changed eventually by pointing to system-installed gdal + sosi + fyba drivers in gdal_environment env variables